### PR TITLE
Atualizei a forma de decodificar o texto

### DIFF
--- a/src/loadRSS.js
+++ b/src/loadRSS.js
@@ -6,15 +6,29 @@ export default class ResolveRSS {
 		this.rssUrl = rssUrl;
 	}
 	getRSSItems(rss) {
+		let charSet = "iso-8859-1";
 		return fetch("https://cors-anywhere.herokuapp.com/" + rss)
+			.then(res => { 
+				charSet = this.getCharsetEncoding(res.headers.get('content-type'));
+				return res; 
+			})
 			.then(res => res.arrayBuffer())
 			.then(rssBffr => {
-				const dec = new TextDecoder("iso-8859-1");
+				const dec = new TextDecoder(charSet);
 				const feedXml = dec.decode(rssBffr);
 				const x2js = new X2JS();
 				const doc = x2js.xml2js(feedXml);
 				return doc.rss.channel.item
 			});
+	}
+
+	getCharsetEncoding(contentTypeHeader) {
+		const regex = /(?<=charset=).*/gm;
+		let match = regex.exec(contentTypeHeader);
+		if (match) {
+			return match[0];
+		}
+		return "iso-8859-1";
 	}
 }
 


### PR DESCRIPTION
- Adicionado método para tentar detectar o charset através response header content-type e caso não encontre usa o iso-8859-1 como padrão;
- TexDecoder dinamico, utilizando o chatset do response header;